### PR TITLE
Log exception message for InitError

### DIFF
--- a/dotNET/PFProSDK/src/PayPal/Payments/Communication/PaymentConnection.cs
+++ b/dotNET/PFProSDK/src/PayPal/Payments/Communication/PaymentConnection.cs
@@ -659,7 +659,7 @@ namespace PayPal.Payments.Communication
 				{
 					ConnContext.AddError(InitError);
 				}
-                Logger.Instance.Log("PayPal.Payments.Communication.PaymentConnection.SendToServer(String): InitError: ", PayflowConstants.SEVERITY_DEBUG);
+                Logger.Instance.Log("PayPal.Payments.Communication.PaymentConnection.SendToServer(String): InitError: " + Ex.Message, PayflowConstants.SEVERITY_DEBUG);
 			}
 			finally
 			{


### PR DESCRIPTION
Although it looks like the message was intended to include this (q..v, the trailing space on the existing log message), we had to change this line to see what was going on.  We hope this will be helpful to others in the future.